### PR TITLE
[Fix]ルーティングのトップページへ遷移できないエラーの修正 #21

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
 
   namespace :admin do
-    get '/' => 'admin#homes'
+    get '/' => 'homes#top'
     resources :items, except: [:destroy]
     resources :genres, only: [:index, :create, :edit, :update]
     resources :customers, only: [:index, :show, :edit, :update]


### PR DESCRIPTION
### エラー修正

- ルーティングの記述が間違っていたのを修正

into develop from routing-fix