### PR TITLE
[Update]カート内に商品がないときページにアクセスさせないようにした

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -11,6 +11,9 @@ class Public::CartItemsController < ApplicationController
   end
 
   def destroy
+    cart_item = CartItem.find(params[:id])
+    cart_item.destroy
+    redirect_to cart_items_path
   end
 
   def destroy_all

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,6 +1,10 @@
 class Public::OrdersController < ApplicationController
   def new
-    @order = Order.new
+    if current_customer.cart_items.blank?
+      redirect_to root_path
+    else
+      @order = Order.new
+    end
   end
 
   def confirm

--- a/app/views/public/cart_items/destroy.html.erb
+++ b/app/views/public/cart_items/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#destroy</h1>
-<p>Find me in app/views/public/cart_items/destroy.html.erb</p>

--- a/app/views/public/cart_items/destroy_all.html.erb
+++ b/app/views/public/cart_items/destroy_all.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#destroy_all</h1>
-<p>Find me in app/views/public/cart_items/destroy_all.html.erb</p>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -4,7 +4,9 @@
       <div class="d-flex my-3">
         <h5 class="my-auto">ショッピングカート</h5>
         <div class="ml-auto">
-          <%= link_to 'カートを空にする', destroy_all_cart_items_path, method: :delete, class: 'btn btn-md btn-danger' %>
+          <% unless current_customer.cart_items.blank? %>
+            <%= link_to 'カートを空にする', destroy_all_cart_items_path, method: :delete, class: 'btn btn-md btn-danger' %>
+          <% end %>
         </div>
       </div>
       <table class="table">
@@ -50,7 +52,9 @@
           </tbody>
         </table>
       </div>
-      <div class="row justify-content-center"><%= link_to '注文情報入力画面', new_order_path, class: 'btn btn-md btn-success my-3' %></div>
+      <% unless current_customer.cart_items.blank? %>
+        <div class="row justify-content-center"><%= link_to '注文情報入力画面', new_order_path, class: 'btn btn-md btn-success my-3' %></div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/public/orders/complete.html.erb
+++ b/app/views/public/orders/complete.html.erb
@@ -1,1 +1,5 @@
-<h1>ご注文ありがとうございました!!</h1>
+<div class="container">
+  <div class="d-flex align-items-center justify-content-center" style="height: 400px">
+    <h1>ご注文ありがとうございました!!</h1>
+  </div>
+</div>


### PR DESCRIPTION
### カートが空の時に
* cart_itemsのindexページにnew_orderとdestroy_allのlinkを表示させないようにした
* new_orderに直接アクセスしてたときにroot_pathにリダイレクトさせるようにした

### ついでに
* cart_item_controllerのdestroy処理のコードがなぜかなかったので追加した
* order_complete画面のレイアウトを調整した

確認よろしくお願いします

debugにcustomer-cart-items-fixをマージします
