### PR TITLE
[Update]before_actionでアドレスの編集と注文詳細への遷移を制限

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -1,5 +1,7 @@
 class Public::AddressesController < ApplicationController
   before_action :authenticate_customer!
+  before_action :ensure_correct_user, only: [:edit, :edit, :destroy]
+
 
   def index
     @addresses = current_customer.addresses.page(params[:page])
@@ -44,5 +46,13 @@ class Public::AddressesController < ApplicationController
 
   def address_params
     params.require(:address).permit(:postal_code, :address, :name)
+  end
+
+  def ensure_correct_user
+    @address = Address.find(params[:id])
+    unless @address.customer == current_customer
+      flash[:danger] = "アカウントが違うため編集できません"
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,5 +1,7 @@
 class Public::OrdersController < ApplicationController
   before_action :authenticate_customer!
+  before_action :ensure_correct_user, only: [:show]
+
   def new
     if current_customer.cart_items.blank?
       redirect_to root_path
@@ -95,5 +97,13 @@ class Public::OrdersController < ApplicationController
 
   def order_params
     params.require(:order).permit(:customer_id, :payment_method, :postal_code, :address, :name, :shipping_cost, :total_payment)
+  end
+
+  def ensure_correct_user
+    @order = Order.find(params[:id])
+    unless @order.customer == current_customer
+      flash[:danger] = "アカウントが違うため閲覧できません"
+      redirect_to root_path
+    end
   end
 end

--- a/app/javascript/stylesheets/favorite.scss
+++ b/app/javascript/stylesheets/favorite.scss
@@ -28,6 +28,9 @@
   &-icon {
     color: #696969;
   }
+  &-small-size a {
+    font-size: 24px;
+  }
   &-size a {
     font-size: 48px;
   }

--- a/app/views/public/favorites/_favorite_index.html.erb
+++ b/app/views/public/favorites/_favorite_index.html.erb
@@ -16,7 +16,7 @@
         </div>
         <% end %>
         <div class="favorite-position-side">
-          <div class="favorite_btn_<%= item.id %>">
+          <div class="favorite_btn_<%= item.id %> favorite-small-size">
             <%= render "public/favorites/favorite", item: item %>
           </div>
         </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -34,7 +34,7 @@
               </div>
             <% end %>
             <div class="favorite-position">
-              <div class="favorite_btn_<%= item.id %>">
+              <div class="favorite_btn_<%= item.id %> favorite-small-size">
                 <%= render "public/favorites/favorite", item: item %>
               </div>
             </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -18,7 +18,7 @@
               </div>
             <% end %>
             <div class="favorite-position">
-              <div class="favorite_btn_<%= item.id %>">
+              <div class="favorite_btn_<%= item.id %> favorite-small-size">
                 <%= render "public/favorites/favorite", item: item %>
               </div>
             </div>

--- a/app/views/public/items/item_search.html.erb
+++ b/app/views/public/items/item_search.html.erb
@@ -13,16 +13,23 @@
             <h5 class=" text-center mb-5">"<%= @search_name %>"の検索に一致する商品は見つかりませんでした</h5>
           <% end %>
           <div class="d-flex flex-wrap justify-content-around">
-            <% @search_result.each do |item| %>
-              <%= link_to item_path(item.id), class:"card mb-3 shadow", style:"padding: 0; height:300px; width: 200px" do %>
-                <%= image_tag item.get_image(200,200), class:"card-img-top",  style:"height:150px; width:auto; object-fit: cover" %>
-                <div class="card-body", style="color:black; background-color:#ffe2d5">
-                  <h5 class="card-title"><%= item.name %></h5>
-                  <p class="card-text">¥<%= item.price.to_s(:delimited) %></p>
-                </div>
-              <% end %>
+          <% @search_result.each do |item| %>
+          <div class="favorite-reference-position">
+            <%= link_to item_path(item.id), class:"card mb-3 item-card", style:"padding: 0;" do %>
+              <%= image_tag item.get_image(200,200), class:"card-img-top",  style:"height:150px; width:auto; object-fit: cover" %>
+              <div class="card-body", style="color:black; background-color:#ffe2d5">
+                <h5 class="card-title"><%= item.name %></h5>
+                <p class="card-text">¥<%= item.price.to_s(:delimited) %></p>
+              </div>
             <% end %>
+            <div class="favorite-position">
+              <div class="favorite_btn_<%= item.id %> favorite-small-size">
+                <%= render "public/favorites/favorite", item: item %>
+              </div>
+            </div>
           </div>
+          <% end %>
+        </div>
           <div class="row justify-content-center">
             <%= paginate @search_result %>
           </div>


### PR DESCRIPTION
### before_actionの追加

- アドレス編集画面
- 注文詳細画面

以上2か所の制限です
他にID付きで遷移しそうなところがあれば追記してください

自分でも確認しましたが確認しておいてください

おまけ**search画面でのアニメーションの追加**
_common-update => debug_